### PR TITLE
Set correct propType on navClass

### DIFF
--- a/components/OwlCarousel.jsx
+++ b/components/OwlCarousel.jsx
@@ -70,7 +70,7 @@ const Owl_Carousel_Options = {
     stageClass: PropTypes.string,
     stageOuterClass: PropTypes.string,
     navContainerClass: PropTypes.string,
-    navClass: PropTypes.string,
+    navClass: PropTypes.arrayOf(PropTypes.string),
     controlsClass: PropTypes.string,
     dotClass: PropTypes.string,
     dotsClass: PropTypes.string,


### PR DESCRIPTION
navClass should be an array of classes: [prevClass, nextClass] and is documented as such, however the propTypes were set to single string. 

Set proptypes to array of strings.